### PR TITLE
Add FileSystem class, improve Pack3r location dialog

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -41,6 +41,8 @@ qt_add_executable(${CMAKE_PROJECT_NAME}
         src/dialog.h
         src/preferences.cpp
         src/preferences.h
+        src/filesystem.cpp
+        src/filesystem.h
         ${app_icon_resource_windows}
         resources/QtPack3r.qrc
 

--- a/src/dialog.cpp
+++ b/src/dialog.cpp
@@ -46,6 +46,9 @@ void Dialog::setupMessageBox(QMessageBox &messageBox, const MessageBox type) {
   case RESET_PREFERENCES:
     setupResetPreferencesMessageBox(messageBox);
     break;
+  case INVALID_PACK3R_BINARY:
+    setupInvalidPack3rBinaryMessageBox(messageBox);
+    break;
   default:
     break;
   }
@@ -93,5 +96,15 @@ void Dialog::setupResetPreferencesMessageBox(QMessageBox &messageBox) {
   messageBox.setText(tr("This will reset all preferences to default values."));
   messageBox.setInformativeText(tr("Are you sure you want to continue?"));
   messageBox.setStandardButtons(QMessageBox::No | QMessageBox::Yes);
+  messageBox.setWindowModality(Qt::ApplicationModal);
+}
+
+void Dialog::setupInvalidPack3rBinaryMessageBox(QMessageBox &messageBox) {
+  messageBox.setWindowTitle(tr("Invalid file selected"));
+  messageBox.setIcon(QMessageBox::Critical);
+  messageBox.setText(tr("Invalid Pack3r executable"));
+  messageBox.setInformativeText(
+      tr("The selected file does not appear to be a valid Pack3r executable. "
+         "Please select a different file."));
   messageBox.setWindowModality(Qt::ApplicationModal);
 }

--- a/src/dialog.h
+++ b/src/dialog.h
@@ -36,6 +36,7 @@ public:
     SAVE_MAPS_PATH,
     PACK3R_RUN_ERROR, // does NOT call setText() nor setInformativeText()
     RESET_PREFERENCES,
+    INVALID_PACK3R_BINARY,
   };
 
   static void setupMessageBox(QMessageBox &messageBox, MessageBox type);
@@ -46,4 +47,5 @@ private:
   static void setupSaveMapsPathMessageBox(QMessageBox &messageBox);
   static void setupPack3rRunErrorMessageBox(QMessageBox &messageBox);
   static void setupResetPreferencesMessageBox(QMessageBox &messageBox);
+  static void setupInvalidPack3rBinaryMessageBox(QMessageBox &messageBox);
 };

--- a/src/filesystem.cpp
+++ b/src/filesystem.cpp
@@ -1,0 +1,52 @@
+/*
+ * MIT License
+ *
+ * Copyright (c) 2025 Aciz
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+#include "filesystem.h"
+#include "preferences.h"
+
+// TODO: support PATH env variable for discovering Pack3r executable?
+QString FileSystem::getPack3rPath(const QString &defaultPath) {
+  return NATIVE_GETFILE(nullptr, tr("Find Pack3r executable"),
+                        getDefaultPath(defaultPath), QString());
+}
+
+QString FileSystem::getMapPath(const QString &defaultPath) {
+  return NATIVE_GETFILE(nullptr, tr("Open map file"),
+                        getDefaultPath(defaultPath),
+                        tr("Radiant map files (*.map *.reg)"));
+}
+
+QString FileSystem::getMappingPath(const QString &defaultPath) {
+  return NATIVE_GETDIR(nullptr, tr("Choose mapping install location"),
+                       getDefaultPath(defaultPath), QFileDialog::ShowDirsOnly);
+}
+
+QString FileSystem::getOutputPath(const QString &defaultPath) {
+  return NATIVE_GETDIR(nullptr, tr("Choose output directory"),
+                       getDefaultPath(defaultPath), QFileDialog::ShowDirsOnly);
+}
+
+QString FileSystem::getDefaultPath(const QString &defaultPath) {
+  return defaultPath.isEmpty() ? QDir::homePath() : defaultPath;
+}

--- a/src/filesystem.cpp
+++ b/src/filesystem.cpp
@@ -45,6 +45,14 @@ QString FileSystem::getPack3rPath(const QString &defaultPath) {
   if (ret == QDialog::Accepted) {
     const QString selectedFile = fileDialog.selectedFiles().first();
 
+    if (!selectedFile.endsWith(PACK3R_EXECUTABLE, Qt::CaseInsensitive)) {
+      QMessageBox dialog{};
+      Dialog::setupMessageBox(dialog,
+                              Dialog::MessageBox::INVALID_PACK3R_BINARY);
+      dialog.exec();
+      return {};
+    }
+
 #ifdef Q_OS_WINDOWS
     return QDir::toNativeSeparators(selectedFile);
 #else

--- a/src/filesystem.h
+++ b/src/filesystem.h
@@ -36,6 +36,14 @@
 
 #define NATIVE_PATHSEP QDir::toNativeSeparators("/")
 
+#ifdef Q_OS_WINDOWS
+// QFileDialog returns forward slashes on Windows too,
+// so we don't use native path separators here
+#define PACK3R_EXECUTABLE "/Pack3r.exe"
+#else
+#define PACK3R_EXECUTABLE "/Pack3r"
+#endif
+
 class FileSystem : public QObject {
 public:
   static QString getPack3rPath(const QString &defaultPath);

--- a/src/filesystem.h
+++ b/src/filesystem.h
@@ -1,0 +1,47 @@
+/*
+ * MIT License
+ *
+ * Copyright (c) 2025 Aciz
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+#pragma once
+
+#include <QFileDialog>
+#include <QObject>
+
+#define NATIVE_GETFILE(parent, caption, dir, filter)                           \
+  QDir::toNativeSeparators(                                                    \
+      QFileDialog::getOpenFileName(parent, caption, dir, filter))
+#define NATIVE_GETDIR(parent, caption, dir, filter)                            \
+  QDir::toNativeSeparators(                                                    \
+      QFileDialog::getExistingDirectory(parent, caption, dir, filter))
+
+#define NATIVE_PATHSEP QDir::toNativeSeparators("/")
+
+class FileSystem : public QObject {
+public:
+  static QString getPack3rPath(const QString &defaultPath);
+  static QString getMapPath(const QString &defaultPath);
+  static QString getMappingPath(const QString &defaultPath);
+  static QString getOutputPath(const QString &defaultPath);
+
+  static QString getDefaultPath(const QString &defaultPath);
+};

--- a/src/preferences.cpp
+++ b/src/preferences.cpp
@@ -23,6 +23,8 @@
  */
 
 #include "preferences.h"
+
+#include "filesystem.h"
 #include "qtpack3r_widget.h"
 
 #include <QApplication>
@@ -237,18 +239,12 @@ void PreferencesDialog::setupInterfacePageConnections() {
 
 void PreferencesDialog::setupPathsPageConnections() {
   connect(pathsPage.mapsPathAction, &QAction::triggered, this, [&] {
-    const QString currentPath =
-        preferences.readSetting(Preferences::Settings::MAPS_PATH).toString();
-    const QString mapsPath =
-        !currentPath.isEmpty() ? currentPath : QDir::homePath();
+    const QString path = FileSystem::getMappingPath(
+        preferences.readSetting(Preferences::Settings::MAPS_PATH).toString());
 
-    const QString newPath =
-        NATIVE_GETDIR(this, tr("Choose mapping install location"), mapsPath,
-                      QFileDialog::ShowDirsOnly);
-
-    if (!newPath.isEmpty()) {
-      preferences.writeSetting(Preferences::Settings::MAPS_PATH, newPath);
-      pathsPage.mapsPathField->setText(newPath);
+    if (!path.isEmpty()) {
+      preferences.writeSetting(Preferences::Settings::MAPS_PATH, path);
+      pathsPage.mapsPathField->setText(path);
     }
   });
 
@@ -258,17 +254,12 @@ void PreferencesDialog::setupPathsPageConnections() {
   });
 
   connect(pathsPage.pack3rPathAction, &QAction::triggered, this, [&] {
-    const QString currentPath =
-        preferences.readSetting(Preferences::Settings::PACK3R_PATH).toString();
-    const QString pack3rPath =
-        !currentPath.isEmpty() ? currentPath : QDir::homePath();
+    const QString path = FileSystem::getPack3rPath(
+        preferences.readSetting(Preferences::Settings::PACK3R_PATH).toString());
 
-    const QString newPath = NATIVE_GETFILE(this, tr("Find Pack3r executable"),
-                                           pack3rPath, QString());
-
-    if (!newPath.isEmpty()) {
-      preferences.writeSetting(Preferences::Settings::PACK3R_PATH, newPath);
-      pathsPage.pack3rPathField->setText(newPath);
+    if (!path.isEmpty()) {
+      preferences.writeSetting(Preferences::Settings::PACK3R_PATH, path);
+      pathsPage.pack3rPathField->setText(path);
     }
   });
 

--- a/src/preferences.h
+++ b/src/preferences.h
@@ -46,8 +46,6 @@
 #define PREFERENCES_FILENAME "preferences.conf"
 #endif
 
-#define NATIVE_PATHSEP QDir::toNativeSeparators("/")
-
 #define SETTINGS_SCHEMA "v1"
 
 class Preferences : public QObject {

--- a/src/qtpack3r_widget.h
+++ b/src/qtpack3r_widget.h
@@ -55,13 +55,6 @@
 #define MONOSPACE_FONT QFont("Consolas")
 #endif
 
-#define NATIVE_GETFILE(parent, caption, dir, filter)                           \
-  QDir::toNativeSeparators(                                                    \
-      QFileDialog::getOpenFileName(parent, caption, dir, filter))
-#define NATIVE_GETDIR(parent, caption, dir, filter)                            \
-  QDir::toNativeSeparators(                                                    \
-      QFileDialog::getExistingDirectory(parent, caption, dir, filter))
-
 class QtPack3rWidget : public QWidget {
   Q_OBJECT
 
@@ -137,10 +130,6 @@ private:
   static bool isValidMapPath(const QString &path);
   void replaceMapFileExtension(QString &str) const;
   void updateOutputExtension() const;
-
-  QString getPack3rPath();
-  QString getMapFile();
-  QString getOutputPath();
 
   const QString noScanDefaultStr = "pak1.pk3 pak2.pk3 mp_bin.pk3";
   const QString noPackDefaultStr =

--- a/src/qtpack3r_widget_path_utils.cpp
+++ b/src/qtpack3r_widget_path_utils.cpp
@@ -24,57 +24,15 @@
 
 // pack3r_widget_filesystem.cpp - filesystem interactions
 
-#include "dialog.h"
-#include "preferences.h"
 #include "qtpack3r_widget.h"
 
-// TODO: support PATH env variable for discovering Pack3r executable?
-QString QtPack3rWidget::getPack3rPath() {
-  const QString path =
-      preferences.readSetting(Preferences::Settings::PACK3R_PATH).toString();
-  QString pack3rPath;
-
-  if (path.isEmpty()) {
-    pack3rPath = QDir::homePath();
-  } else {
-    auto splits = path.split(NATIVE_PATHSEP);
-    splits.removeLast();
-    pack3rPath = splits.join(NATIVE_PATHSEP);
-  }
-
-  return NATIVE_GETFILE(this, tr("Find Pack3r executable"), pack3rPath,
-                        QString());
-}
-
-QString QtPack3rWidget::getMapFile() {
-  const QString path =
-      preferences.readSetting(Preferences::Settings::MAPS_PATH).toString();
-
-  QString mapsPath;
-
-  if (path.isEmpty()) {
-    mapsPath = QDir::homePath();
-    ui.paths.defaultMapPathSet = false;
-  } else {
-    mapsPath = path;
-    ui.paths.defaultMapPathSet = true;
-  }
-
-  return NATIVE_GETFILE(this, tr("Open map file"), mapsPath,
-                        tr("Radiant map files (*.map *.reg)"));
-}
-
-QString QtPack3rWidget::getOutputPath() {
-  const QString path =
-      preferences.readSetting(Preferences::Settings::MAPS_PATH).toString();
-  const QString mapsPath = !path.isEmpty() ? path : QDir::homePath();
-
-  return NATIVE_GETDIR(this, tr("Choose output directory"), mapsPath,
-                       QFileDialog::ShowDirsOnly);
-}
+#include "dialog.h"
+#include "filesystem.h"
+#include "preferences.h"
 
 void QtPack3rWidget::findPack3r() {
-  const QString path = getPack3rPath();
+  const QString path = FileSystem::getPack3rPath(
+      preferences.readSetting(Preferences::Settings::PACK3R_PATH).toString());
 
   if (!path.isEmpty()) {
     ui.paths.pack3rPathField->setText(path);
@@ -85,7 +43,11 @@ void QtPack3rWidget::findPack3r() {
 }
 
 void QtPack3rWidget::openMap() {
-  const QString path = getMapFile();
+  const QString defaultPath =
+      preferences.readSetting(Preferences::Settings::MAPS_PATH).toString();
+  ui.paths.defaultMapPathSet = !defaultPath.isEmpty();
+
+  const QString path = FileSystem::getMapPath(defaultPath);
 
   if (path.isEmpty()) {
     return;
@@ -127,7 +89,8 @@ void QtPack3rWidget::openMap() {
 }
 
 void QtPack3rWidget::setOutput() {
-  QString path = getOutputPath();
+  QString path = FileSystem::getOutputPath(
+      preferences.readSetting(Preferences::Settings::MAPS_PATH).toString());
 
   if (path.isEmpty()) {
     return;


### PR DESCRIPTION
* Move `QFileDialog` operations to a separate `FileSystem` class
* Only allow executable files when locating Pack3r
  * Windows filters to `.exe`, Linux checks for executable bit once file is selected
* Add simple validation to Pack3r executable name - `Pack3r.exe` on Windows, `Pack3r` on Linux

fixes #10 