### PR TITLE
Update Pack3r path on UI if changed from preferences

### DIFF
--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -34,7 +34,10 @@
 inline constexpr int DEFAULT_WIDTH = 800;
 inline constexpr int DEFAULT_HEIGHT = 800;
 
-MainWindow::MainWindow() : qtPack3rwidget(new QtPack3rWidget(this)) {
+MainWindow::MainWindow() {
+  preferencesDialog = new PreferencesDialog(this);
+  qtPack3rwidget = new QtPack3rWidget(this, preferencesDialog);
+
   setupGeometry();
   setupMenuBar();
   setCentralWidget(qtPack3rwidget);
@@ -229,10 +232,13 @@ void MainWindow::buildAboutDialog() {
   layout->addLayout(buttonLayout, 0);
 }
 
-void MainWindow::openPreferences() {
-  PreferencesDialog preferencesDialog{};
-  preferencesDialog.buildPreferencesDialog();
-  preferencesDialog.preferencesDialog->exec();
+void MainWindow::openPreferences() const {
+  if (!preferencesDialog->dialog) {
+    preferencesDialog->buildPreferencesDialog();
+  }
+
+  preferencesDialog->setInitialState();
+  preferencesDialog->dialog->exec();
 }
 
 void MainWindow::openAboutWindow() {

--- a/src/mainwindow.h
+++ b/src/mainwindow.h
@@ -40,6 +40,7 @@
 #define GIT_COMMIT_HASH_SHORT "n/a"
 #endif
 
+#include "preferences.h"
 #include "qtpack3r_widget.h"
 
 #include <QApplication>
@@ -63,6 +64,7 @@ private:
   void buildAboutDialog();
 
   QtPack3rWidget *qtPack3rwidget{};
+  PreferencesDialog *preferencesDialog{};
 
   const QString pack3rLink = "https://github.com/ovska/Pack3r/releases/latest";
   const QString qtPack3rLink = "https://github.com/Aciz/QtPack3r";
@@ -86,7 +88,7 @@ private:
   QDialog *aboutDialog{};
 
 private slots:
-  void openPreferences();
+  void openPreferences() const;
   void openAboutWindow();
   void openPack3rLink() const;
   void openBugReportLink() const;

--- a/src/preferences.h
+++ b/src/preferences.h
@@ -96,8 +96,15 @@ class PreferencesDialog : public QWidget {
   Q_OBJECT
 
 public:
+  explicit PreferencesDialog(QWidget *parent);
+
   void buildPreferencesDialog();
-  QDialog *preferencesDialog{};
+  void setInitialState();
+
+  QDialog *dialog{};
+
+signals:
+  void pack3rPathChanged(const QString &newPath);
 
 private:
   void buildInterfacePage();
@@ -128,6 +135,7 @@ private:
 
     QLabel *pack3rPathLabel{};
     QLineEdit *pack3rPathField{};
+    QString oldPack3rPath{};
     QAction *pack3rPathAction{};
 
     QLabel *mapsPathLabel{};

--- a/src/qtpack3r_widget.cpp
+++ b/src/qtpack3r_widget.cpp
@@ -34,7 +34,9 @@
 #include <QMimeData>
 #include <QSignalBlocker>
 
-QtPack3rWidget::QtPack3rWidget(QWidget *parent) : QWidget(parent) {
+QtPack3rWidget::QtPack3rWidget(
+    QWidget *parent, const QPointer<PreferencesDialog> &preferencesDialogPtr)
+    : QWidget(parent), preferencesDialog(preferencesDialogPtr) {
   setupCommands();
 
   outputParser = new Pack3rOutputParser(this);
@@ -202,4 +204,9 @@ void QtPack3rWidget::resetWidgetState() {
 
 void QtPack3rWidget::updatePack3rOutput(const QByteArray &data) const {
   ui.output.outputField->appendPlainText(data);
+}
+
+void QtPack3rWidget::updatePack3rPath(const QString &newPath) {
+  ui.paths.pack3rPathField->setText(newPath);
+  updateCommandPreview();
 }

--- a/src/qtpack3r_widget.h
+++ b/src/qtpack3r_widget.h
@@ -26,6 +26,7 @@
 
 #include "pack3r_output_parser.h"
 #include "pack3r_process_handler.h"
+#include "preferences.h"
 
 #include <QApplication>
 #include <QButtonGroup>
@@ -59,7 +60,8 @@ class QtPack3rWidget : public QWidget {
   Q_OBJECT
 
 public:
-  explicit QtPack3rWidget(QWidget *parent);
+  QtPack3rWidget(QWidget *parent,
+                 const QPointer<PreferencesDialog> &preferencesDialogPtr);
 
 public slots:
   void findPack3r();
@@ -142,6 +144,7 @@ private:
   QClipboard *clipboard{};
   Pack3rProcessHandler *processHandler;
   QPointer<Pack3rOutputParser> outputParser;
+  QPointer<PreferencesDialog> preferencesDialog;
 
   QGridLayout *layout{};
 
@@ -251,4 +254,5 @@ private slots:
   void updatePack3rOutput(const QByteArray &data) const;
   void copyFieldToClipboard(const QPlainTextEdit *field) const;
   void resetWidgetState();
+  void updatePack3rPath(const QString &newPath);
 };

--- a/src/qtpack3r_widget_connections.cpp
+++ b/src/qtpack3r_widget_connections.cpp
@@ -37,6 +37,9 @@ void QtPack3rWidget::setupPathsConnections() {
   connect(ui.paths.pack3rPathAction, &QAction::triggered, this,
           &QtPack3rWidget::findPack3r);
 
+  connect(preferencesDialog, &PreferencesDialog::pack3rPathChanged, this,
+          &QtPack3rWidget::updatePack3rPath);
+
   connect(ui.paths.mapPathAction, &QAction::triggered, this,
           &QtPack3rWidget::openMap);
 


### PR DESCRIPTION
Updates when the preferences dialog is closed. The dialog is now also a member of the main window, and is no longer rebuilt from scratch each time the dialog is opened.