### PR TITLE
Validate Pack3r binary when editing Preferences text field

### DIFF
--- a/src/filesystem.cpp
+++ b/src/filesystem.cpp
@@ -64,11 +64,7 @@ QString FileSystem::getPack3rPath(const QString &defaultPath) {
   if (ret == QDialog::Accepted) {
     const QString selectedFile = fileDialog.selectedFiles().first();
 
-    if (!selectedFile.endsWith(PACK3R_EXECUTABLE, Qt::CaseInsensitive)) {
-      QMessageBox dialog{};
-      Dialog::setupMessageBox(dialog,
-                              Dialog::MessageBox::INVALID_PACK3R_BINARY);
-      dialog.exec();
+    if (!isValidPack3rBinary(selectedFile)) {
       return {};
     }
 
@@ -107,4 +103,19 @@ QString FileSystem::getOutputPath(const QString &defaultPath) {
 
 QString FileSystem::getDefaultPath(const QString &defaultPath) {
   return defaultPath.isEmpty() ? QDir::homePath() : defaultPath;
+}
+
+bool FileSystem::isValidPack3rBinary(const QString &file, const bool silent) {
+  if (!file.endsWith(PACK3R_EXECUTABLE, Qt::CaseInsensitive)) {
+    if (!silent) {
+      QMessageBox dialog{};
+      Dialog::setupMessageBox(dialog,
+                              Dialog::MessageBox::INVALID_PACK3R_BINARY);
+      dialog.exec();
+    }
+
+    return false;
+  }
+
+  return true;
 }

--- a/src/filesystem.h
+++ b/src/filesystem.h
@@ -52,4 +52,6 @@ public:
   static QString getOutputPath(const QString &defaultPath);
 
   static QString getDefaultPath(const QString &defaultPath);
+  // if silent is true, just checks for validity without creating a dialog
+  static bool isValidPack3rBinary(const QString &file, bool silent = false);
 };

--- a/src/preferences.cpp
+++ b/src/preferences.cpp
@@ -267,8 +267,23 @@ void PreferencesDialog::setupPathsPageConnections() {
   });
 
   connect(pathsPage.pack3rPathField, &QLineEdit::editingFinished, this, [&] {
-    preferences.writeSetting(Preferences::Settings::PACK3R_PATH,
-                             pathsPage.pack3rPathField->text());
+    if (FileSystem::isValidPack3rBinary(pathsPage.pack3rPathField->text())) {
+      preferences.writeSetting(Preferences::Settings::PACK3R_PATH,
+                               pathsPage.pack3rPathField->text());
+    } else {
+      // try to restore from settings
+      const QString oldFile =
+          preferences.readSetting(Preferences::Settings::PACK3R_PATH)
+              .toString();
+
+      if (FileSystem::isValidPack3rBinary(oldFile, true)) {
+        pathsPage.pack3rPathField->setText(oldFile);
+      } else {
+        // fallback, just clear the field and remove the bad entry from settings
+        preferences.writeSetting(Preferences::Settings::PACK3R_PATH, "");
+        pathsPage.pack3rPathField->clear();
+      }
+    }
   });
 }
 


### PR DESCRIPTION
Only the file picker had validation, but not manual text field editing.