### PR TITLE
Make Linux executable permission errors more specific

### DIFF
--- a/src/filesystem.cpp
+++ b/src/filesystem.cpp
@@ -77,11 +77,13 @@ QString FileSystem::getPack3rPath(const QString &defaultPath) {
 #else
     const QFileInfo fileInfo(selectedFile);
 
-    if (fileInfo.isExecutable()) {
-      return QDir::toNativeSeparators(selectedFile);
+    if (!fileInfo.isExecutable()) {
+      QMessageBox::critical(
+          nullptr, "Invalid file permissions",
+          QString("File '%1' is not executable. Check the file permissions.")
+              .arg(selectedFile));
     } else {
-      QMessageBox::critical(nullptr, "Invalid file",
-                            "The selected file is not an executable file.");
+      return QDir::toNativeSeparators(selectedFile);
     }
 #endif
   }

--- a/src/qtpack3r_widget.cpp
+++ b/src/qtpack3r_widget.cpp
@@ -129,6 +129,20 @@ bool QtPack3rWidget::canRunPack3r() const {
     canRun = false;
   }
 
+  // check file permissions on Linux, so we don't silently error
+#ifdef Q_OS_LINUX
+  const QFileInfo fileInfo(ui.paths.pack3rPathField->text());
+
+  if (!fileInfo.isExecutable()) {
+    QMessageBox::critical(
+        nullptr, "Invalid file permissions",
+        QString("File '%1' is not executable. Check the file permissions.")
+            .arg(ui.paths.pack3rPathField->text()));
+    // return here so we don't get double dialogs
+    return false;
+  }
+#endif
+
   if (!canRun) {
     dialog.exec();
   }


### PR DESCRIPTION
Also add the check to canRunPack3r in case the file permissions are modified after the executable is selected, or settings are manually tweaked.