### PR TITLE
Make preferences path fields read-only

### DIFF
--- a/src/filesystem.cpp
+++ b/src/filesystem.cpp
@@ -64,7 +64,11 @@ QString FileSystem::getPack3rPath(const QString &defaultPath) {
   if (ret == QDialog::Accepted) {
     const QString selectedFile = fileDialog.selectedFiles().first();
 
-    if (!isValidPack3rBinary(selectedFile)) {
+    if (!selectedFile.endsWith(PACK3R_EXECUTABLE, Qt::CaseInsensitive)) {
+      QMessageBox dialog{};
+      Dialog::setupMessageBox(dialog,
+                              Dialog::MessageBox::INVALID_PACK3R_BINARY);
+      dialog.exec();
       return {};
     }
 
@@ -105,19 +109,4 @@ QString FileSystem::getOutputPath(const QString &defaultPath) {
 
 QString FileSystem::getDefaultPath(const QString &defaultPath) {
   return defaultPath.isEmpty() ? QDir::homePath() : defaultPath;
-}
-
-bool FileSystem::isValidPack3rBinary(const QString &file, const bool silent) {
-  if (!file.endsWith(PACK3R_EXECUTABLE, Qt::CaseInsensitive)) {
-    if (!silent) {
-      QMessageBox dialog{};
-      Dialog::setupMessageBox(dialog,
-                              Dialog::MessageBox::INVALID_PACK3R_BINARY);
-      dialog.exec();
-    }
-
-    return false;
-  }
-
-  return true;
 }

--- a/src/filesystem.h
+++ b/src/filesystem.h
@@ -52,6 +52,4 @@ public:
   static QString getOutputPath(const QString &defaultPath);
 
   static QString getDefaultPath(const QString &defaultPath);
-  // if silent is true, just checks for validity without creating a dialog
-  static bool isValidPack3rBinary(const QString &file, bool silent = false);
 };

--- a/src/preferences.cpp
+++ b/src/preferences.cpp
@@ -169,6 +169,7 @@ void PreferencesDialog::buildPathsPage() {
 
   pathsPage.pack3rPathField = new QLineEdit(pathsPage.groupBox);
   pathsPage.pack3rPathField->setToolTip(pack3rPathTooltip);
+  pathsPage.pack3rPathField->setReadOnly(true);
 
   pathsPage.pack3rPathAction = new QAction(pathsPage.groupBox);
   pathsPage.pack3rPathAction = pathsPage.pack3rPathField->addAction(
@@ -181,6 +182,7 @@ void PreferencesDialog::buildPathsPage() {
 
   pathsPage.mapsPathField = new QLineEdit(pathsPage.groupBox);
   pathsPage.mapsPathField->setToolTip(mapsPathTooltip);
+  pathsPage.mapsPathField->setReadOnly(true);
 
   pathsPage.mapsPathAction = new QAction(pathsPage.groupBox);
   pathsPage.mapsPathAction = pathsPage.mapsPathField->addAction(
@@ -238,11 +240,6 @@ void PreferencesDialog::setupPathsPageConnections() {
     }
   });
 
-  connect(pathsPage.mapsPathField, &QLineEdit::editingFinished, this, [&] {
-    preferences.writeSetting(Preferences::Settings::MAPS_PATH,
-                             pathsPage.mapsPathField->text());
-  });
-
   connect(pathsPage.pack3rPathAction, &QAction::triggered, this, [&] {
     const QString path = FileSystem::getPack3rPath(
         preferences.readSetting(Preferences::Settings::PACK3R_PATH).toString());
@@ -251,11 +248,6 @@ void PreferencesDialog::setupPathsPageConnections() {
       preferences.writeSetting(Preferences::Settings::PACK3R_PATH, path);
       pathsPage.pack3rPathField->setText(path);
     }
-  });
-
-  connect(pathsPage.pack3rPathField, &QLineEdit::editingFinished, this, [&] {
-    preferences.writeSetting(Preferences::Settings::PACK3R_PATH,
-                             pathsPage.pack3rPathField->text());
   });
 }
 

--- a/src/preferences.cpp
+++ b/src/preferences.cpp
@@ -254,23 +254,8 @@ void PreferencesDialog::setupPathsPageConnections() {
   });
 
   connect(pathsPage.pack3rPathField, &QLineEdit::editingFinished, this, [&] {
-    if (FileSystem::isValidPack3rBinary(pathsPage.pack3rPathField->text())) {
-      preferences.writeSetting(Preferences::Settings::PACK3R_PATH,
-                               pathsPage.pack3rPathField->text());
-    } else {
-      // try to restore from settings
-      const QString oldFile =
-          preferences.readSetting(Preferences::Settings::PACK3R_PATH)
-              .toString();
-
-      if (FileSystem::isValidPack3rBinary(oldFile, true)) {
-        pathsPage.pack3rPathField->setText(oldFile);
-      } else {
-        // fallback, just clear the field and remove the bad entry from settings
-        preferences.writeSetting(Preferences::Settings::PACK3R_PATH, "");
-        pathsPage.pack3rPathField->clear();
-      }
-    }
+    preferences.writeSetting(Preferences::Settings::PACK3R_PATH,
+                             pathsPage.pack3rPathField->text());
   });
 }
 


### PR DESCRIPTION
This is just a whole lot simpler implementation wise, there's no real need to have these editable by hand.